### PR TITLE
Rasa dutch

### DIFF
--- a/Rasa_Bot/README.md
+++ b/Rasa_Bot/README.md
@@ -14,6 +14,9 @@ The steps are as follows:
    - The output for the above command should be something like this: [{"recipient_id":"user","text":"Hey Kees!"},{"recipient_id":"user","text":"Sure, you should ...
    - See [this page](https://rasa.com/docs/rasa/connectors/your-own-website#restinput) for details on how to use the REST channel.
    
+## Language
+Currently, the NLU-model does not use any pre-trained embeddings. If in the future we want to recognize named entities, it might be useful to add such pre-trained embeddings, e.g. via Spacy. More information is provided [here](https://rasa.com/docs/rasa/tuning-your-model). Note that using Spacy requires installing spacy as well as the specific embeddings, e.g. "nl_core_news_lg."
+
 ## Conversation Flow
 The agent is built for a very simple conversation, as shown in the image below.
 

--- a/Rasa_Bot/README.md
+++ b/Rasa_Bot/README.md
@@ -1,4 +1,4 @@
-This is a simple conversational agent implemented in Rasa 2.0.2.
+This is a simple conversational agent implemented in Rasa 2.0.2 with a Dutch language model.
 
 All conversations are stored in memory, which means that they are lost once the Rasa server is restarted. It is possible to set up a tracker store so that the conversations persist. See [this page](https://rasa.com/docs/rasa/tracker-stores) for more information.
 
@@ -10,7 +10,7 @@ The steps are as follows:
 - Make sure that you have Docker and Docker Compose installed. You can check whether you do by typing `docker -v && docker-compose -v`.
 - Navigate to the "Rasa_Bot"-folder on your laptop.
 - Type `docker-compose up`.
-- Now you can communicate with the bot via its REST API. E.g. on Windows, type `curl http://localhost:5005/webhooks/rest/webhook -d "{\"message\": \"Could you please send me the planning for next week?\", \"sender\":\"user\"}"`. Note that the escaping of the double-quotes is a fix that is needed on Windows.
+- Now you can communicate with the bot via its REST API. E.g. on Windows, type `curl http://localhost:5005/webhooks/rest/webhook -d "{\"message\": \"Hey, kun je me de agenda voor de week vertellen?\", \"sender\":\"user\"}"`. Note that the escaping of the double-quotes is a fix that is needed on Windows.
    - The output for the above command should be something like this: [{"recipient_id":"user","text":"Hey Kees!"},{"recipient_id":"user","text":"Sure, you should ...
    - See [this page](https://rasa.com/docs/rasa/connectors/your-own-website#restinput) for details on how to use the REST channel.
    

--- a/Rasa_Bot/config.yml
+++ b/Rasa_Bot/config.yml
@@ -1,6 +1,6 @@
 # Configuration for Rasa NLU.
 # https://rasa.com/docs/rasa/nlu/components/ 
-language: en
+language: nl
 
 pipeline:
 # # No configuration for the NLU pipeline was provided. The following default pipeline was used to train your model.

--- a/Rasa_Bot/config.yml
+++ b/Rasa_Bot/config.yml
@@ -6,22 +6,26 @@ pipeline:
 # # No configuration for the NLU pipeline was provided. The following default pipeline was used to train your model.
 # # If you'd like to customize it, uncomment and adjust the pipeline.
 # # See https://rasa.com/docs/rasa/tuning-your-model for more information.
-#   - name: WhitespaceTokenizer
-#   - name: RegexFeaturizer
-#   - name: LexicalSyntacticFeaturizer
-#   - name: CountVectorsFeaturizer
-#   - name: CountVectorsFeaturizer
-#     analyzer: char_wb
-#     min_ngram: 1
-#     max_ngram: 4
-#   - name: DIETClassifier
-#     epochs: 100
-#   - name: EntitySynonymMapper
-#   - name: ResponseSelector
-#     epochs: 100
-#   - name: FallbackClassifier
-#     threshold: 0.3
-#     ambiguity_threshold: 0.1
+   - name: WhitespaceTokenizer
+   - name: RegexFeaturizer
+   - name: LexicalSyntacticFeaturizer
+   - name: CountVectorsFeaturizer
+   - name: CountVectorsFeaturizer
+     analyzer: char_wb
+     min_ngram: 1
+     max_ngram: 4
+   - name: rasa_nlu_examples.featurizers.dense.BytePairFeaturizer
+     lang: nl
+     vs: 1000
+     dim: 25
+   - name: DIETClassifier
+     epochs: 100
+   - name: EntitySynonymMapper
+   - name: ResponseSelector
+     epochs: 100
+   - name: FallbackClassifier
+     threshold: 0.3
+     ambiguity_threshold: 0.1
 
 # Configuration for Rasa Core.
 # https://rasa.com/docs/rasa/core/policies/

--- a/Rasa_Bot/config.yml
+++ b/Rasa_Bot/config.yml
@@ -3,29 +3,20 @@
 language: nl
 
 pipeline:
-# # No configuration for the NLU pipeline was provided. The following default pipeline was used to train your model.
-# # If you'd like to customize it, uncomment and adjust the pipeline.
-# # See https://rasa.com/docs/rasa/tuning-your-model for more information.
-   - name: WhitespaceTokenizer
-   - name: RegexFeaturizer
-   - name: LexicalSyntacticFeaturizer
-   - name: CountVectorsFeaturizer
-   - name: CountVectorsFeaturizer
-     analyzer: char_wb
-     min_ngram: 1
-     max_ngram: 4
-   - name: rasa_nlu_examples.featurizers.dense.BytePairFeaturizer
-     lang: nl
-     vs: 1000
-     dim: 25
-   - name: DIETClassifier
-     epochs: 100
-   - name: EntitySynonymMapper
-   - name: ResponseSelector
-     epochs: 100
-   - name: FallbackClassifier
-     threshold: 0.3
-     ambiguity_threshold: 0.1
+# See https://rasa.com/docs/rasa/tuning-your-model for more information.
+  - name: WhitespaceTokenizer
+  - name: RegexFeaturizer
+  - name: LexicalSyntacticFeaturizer
+  - name: CountVectorsFeaturizer
+  - name: CountVectorsFeaturizer
+    analyzer: "char_wb"
+    min_ngram: 1
+    max_ngram: 4
+  - name: DIETClassifier
+    epochs: 100
+  - name: EntitySynonymMapper
+  - name: ResponseSelector
+    epochs: 100
 
 # Configuration for Rasa Core.
 # https://rasa.com/docs/rasa/core/policies/

--- a/Rasa_Bot/data/nlu.yml
+++ b/Rasa_Bot/data/nlu.yml
@@ -3,28 +3,30 @@ version: "2.0"
 nlu:
 - intent: request_plan_week
   examples: |
-    - Can I get the planning for next week?
-    - Could you please send me the planning for next week?
-    - What is the planning for the coming week?
-    - What is planned for next week?
-    - Could you please tell me the plan for next week?
-    - Hey, can I get the planning for next week?
+    - "Kan ik de agende voor de week krijgen?"
+    - "Kun je de agenda voor de week opsturen?"
+    - "Wat is de agenda voor de komende week?"
+    - "Wat is er gepland voor de komende week?"
+    - "Kun je me de agenda voor de komende week vertellen?"
+    - "Hey, kun je me de agenda voor de week vertellen?"
     
 - intent: confirm
   examples: |
-    - Yes, please
-    - Yeah
-    - Of course
-    - Yes
-    - Yes please do that
-    - That would be great
-    - Yes that would be nice
-    - Ah yes please
+    - Ja graag
+    - Zeker
+    - Natuurlijk
+    - Ja doe dat alsjeblieft
+    - Ja
+    - Dat zou fijn zijn
+    - Ah ja
+    - Graag
     
 - intent: deny
   examples: |
-    - "No thanks."
-    - "Thanks, but that's not needed."
-    - "No thank you."
-    - "Not this time, thanks."
+    - "Nee, dank je wel."
+    - "Nee, dank u wel."
+    - "Bedankt, maar dat hoeft niet."
+    - "Deze keer niet, dank je."
+    - "Dat hoeft niet."
+    - "Nee, bedankt."
   

--- a/Rasa_Bot/domain.yml
+++ b/Rasa_Bot/domain.yml
@@ -24,21 +24,20 @@ responses:
   utter_greet:
   - text: "Hey {name}!"
   - text: "Hi {name}!"
-  - text: "Hello {name}!"
+  - text: "Hallo {name}!"
   utter_plan_week:
   - text: "{plan_week}"
   utter_ask_plan_calendar:
-  - text: "Do you want me to add this plan to your calendar?"
-  - text: "Would you like me to add this plan to your calendar?"
-  - text: "Should I add this to your calendar?"
+  - text: "Zal ik het plan in je agenda zetten?"
+  - text: "Wil je dat ik het plan in je agenda zet?"
   utter_plan_calendar_confirmation:
-  - text: "Cool, I've added it to your calendar for next week."
-  - text: "Okay, it's in your calendar now."
+  - text: "Cool, ik heb het plan in je agenda ingevoerd."
+  - text: "Okay, het plan staat nu in je agenda."
   utter_okay:
   - text: "Okay!"
   - text: "OK!"
   utter_error_save_plan_week_calendar:
-  - text: "I'm sorry, I can't save the plan in your calendar at the moment."
+  - text: "Sorry, ik kan het plan nu niet invoeren."
   
 actions:
 - action_get_plan_week


### PR DESCRIPTION
The main language of the Rasa agent now is Dutch. In the future, it might be nice to also use pretrained Dutch embeddings. But for now that is not needed.

Please test it by sending a request with a Dutch message to the Rest API and inspecting whether the agent responds with "Hey Kees", etc. This is described in the Readme in the Rasa_Bot folder.