### PR TITLE
Run ci once

### DIFF
--- a/.github/workflows/node-js-build.yml
+++ b/.github/workflows/node-js-build.yml
@@ -1,6 +1,13 @@
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  # Trigger analysis when pushing in master or pull requests, and when creating
+  # a pull request.
+  push:
+    branches:
+      - main
+  pull_request:
+      types: [opened, synchronize, reopened]
 
 
 jobs:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,7 +1,13 @@
 name: Python CI
 
-on: [push, pull_request]
-
+on:
+  # Trigger analysis when pushing in master or pull requests, and when creating
+  # a pull request.
+  push:
+    branches:
+      - main
+  pull_request:
+      types: [opened, synchronize, reopened]
 jobs:
 
   build:


### PR DESCRIPTION
See #72 . There all build CI is run twice, because of the `on` rule in the `.yml` file being triggered for both push and pull request. This PR changes that.