### PR TITLE
Add scripts to bootstrap before running docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=PerfectFit-project_virtual-coach-server&metric=coverage)](https://sonarcloud.io/dashboard?id=PerfectFit-project_virtual-coach-server)
 
 # PerfectFit virtual coach server functional prototype
-This should become a working functional prototype that can handle the following scenario. It is a functional system that facilitates a subset of the must have requirements, that can easily be extended with specific content to match the patient journey. It is not yet production ready.  
+This should become a working functional prototype that can handle the following scenario. It is a functional system that facilitates a subset of the must have requirements, that can easily be extended with specific content to match the patient journey. It is not yet production ready.
 
-* User sends a message in the NiceDay app with the intent to get the planning for the next week 
-* In response the Virtual Coach sends back the weekly planning that should include: 
-  - Hey {name}, where the name is retrieved from the database 
+* User sends a message in the NiceDay app with the intent to get the planning for the next week
+* In response the Virtual Coach sends back the weekly planning that should include:
+  - Hey {name}, where the name is retrieved from the database
   - One planned event is to read through some psycho-education that comes from a ‘content’ file (that will later be controlled by Leiden)
   - A suggestion for physical exercises from algorithm (nice to have)
 
@@ -25,11 +25,11 @@ See [software development planning document](https://nlesc.sharepoint.com/:w:/r/
 Take a look at the design [here](docs/design.md).
 
 ## Setup using docker-compose
-1. See `niceday-api/` for getting the therapist user id and token. 
+1. See `niceday-api/` for getting the therapist user id and token.
 2. Create a file called `.env` in the root of this app.
 Save the therapist user id and token in your `.env` file as THERAPIST_USER_ID and NICEDAY_TOKEN respectively,
 see .env-example. These will be loaded as environment variables and will thus be available in the app.
-NB: The token expires, so you need to replace it once in a while. 
+NB: The token expires, so you need to replace it once in a while.
 You will get a `ChatNotAuthorizedError` if the token is invalid.
-3. Run `./script/server`. This will install the right dependencies, build docker images, and 
+3. Run `./script/server`. This will install the right dependencies, build docker images, and
 run them.

--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ Save the therapist user id and token in your `.env` file as THERAPIST_USER_ID an
 see .env-example. These will be loaded as environment variables and will thus be available in the app.
 NB: The token expires, so you need to replace it once in a while. 
 You will get a `ChatNotAuthorizedError` if the token is invalid.
-3. Run `docker-compose --env-file .env up`
+3. Run `./script/server`. This will install the right dependencies, build docker images, and 
+run them.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,5 @@ services:
     expose: ["5055"]
   niceday-broker:
     build: niceday-broker/
+    env_file:
+      - .env

--- a/niceday-api/Dockerfile
+++ b/niceday-api/Dockerfile
@@ -5,4 +5,7 @@ WORKDIR /app
 COPY ["package.json", "package-lock.json*", "./"]
 COPY . .
 
+# Install goalie-js from cloned repository
+RUN npm install ./build/goalie-js
+
 CMD [ "npm", "start" ]

--- a/niceday-api/README.md
+++ b/niceday-api/README.md
@@ -33,7 +33,18 @@ open http://localhost:8080/docs
 
 From there you can easily test out the different endpoints
 
-This project leverages [oas3-tools](https://www.npmjs.com/package/oas3-tools) middleware which does most all the work.
+### Running with docker
+Run the following commands:
+```
+./script/bootstrap
+docker build -t niceday-api .
+docker run --env-file .env niceday-api
+```
+
+See [root README](../README.md) for instructions of running 
+the full application with docker-compose.
 
 ### What is my user id?
 Just run `node login.mjs emailaddress password` with a user's credentials to find out the user id.
+
+This project leverages [oas3-tools](https://www.npmjs.com/package/oas3-tools) middleware which does most all the work.

--- a/niceday-api/script/bootstrap
+++ b/niceday-api/script/bootstrap
@@ -1,0 +1,2 @@
+#!/bin/bash
+npm install

--- a/niceday-api/script/bootstrap
+++ b/niceday-api/script/bootstrap
@@ -1,2 +1,2 @@
 #!/bin/bash
-npm install
+npm git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js

--- a/niceday-api/script/bootstrap
+++ b/niceday-api/script/bootstrap
@@ -1,2 +1,4 @@
 #!/bin/bash
-npm git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js
+if [[ ! -d "./build/goalie-js" ]]; then
+    git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2
+fi

--- a/niceday-broker/Dockerfile
+++ b/niceday-broker/Dockerfile
@@ -2,7 +2,6 @@ FROM node:14.16.1
 
 WORKDIR /app
 
-COPY ["package.json", "package-lock.json*", "./"]
 COPY . .
 
 # Install goalie-js from cloned repository

--- a/niceday-broker/Dockerfile
+++ b/niceday-broker/Dockerfile
@@ -5,4 +5,7 @@ WORKDIR /app
 COPY ["package.json", "package-lock.json*", "./"]
 COPY . .
 
+# Install goalie-js from cloned repository
+RUN npm install ./build/goalie-js
+
 CMD [ "npm", "start" ]

--- a/niceday-broker/README.md
+++ b/niceday-broker/README.md
@@ -24,7 +24,13 @@ To run the server, run:
 npm start
 ```
 
-### Running the full Niceday conversational agent application
-You'll need to run both this niceday-router and the Rasa_Bot 
-(see [Readme of Rasa_Bot](https://github.com/PerfectFit-project/virtual-coach-server/blob/main/Rasa_Bot/README.md)) 
-to have a working conversational agent in the Niceday app.
+### Running with docker
+Run the following commands:
+```
+./script/bootstrap
+docker build -t niceday-broker .
+docker run --env-file .env niceday-broker
+```
+
+See [root README](../README.md) for instructions of running 
+the full application with docker-compose.

--- a/niceday-broker/script/bootstrap
+++ b/niceday-broker/script/bootstrap
@@ -1,0 +1,2 @@
+#!/bin/bash
+npm install .

--- a/niceday-broker/script/bootstrap
+++ b/niceday-broker/script/bootstrap
@@ -1,2 +1,2 @@
 #!/bin/bash
-npm install .
+git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js

--- a/niceday-broker/script/bootstrap
+++ b/niceday-broker/script/bootstrap
@@ -1,3 +1,4 @@
 #!/bin/bash
-rm -rf ./build/goalie-js
-git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2
+if [[ ! -d "./build/goalie-js" ]]; then
+    git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2
+fi

--- a/niceday-broker/script/bootstrap
+++ b/niceday-broker/script/bootstrap
@@ -1,3 +1,3 @@
 #!/bin/bash
 rm -rf ./build/goalie-js
-git clone https://github.com/senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2
+git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2

--- a/niceday-broker/script/bootstrap
+++ b/niceday-broker/script/bootstrap
@@ -1,2 +1,3 @@
 #!/bin/bash
-git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2
+rm -rf ./build/goalie-js
+git clone https://github.com/senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2

--- a/niceday-broker/script/bootstrap
+++ b/niceday-broker/script/bootstrap
@@ -1,2 +1,2 @@
 #!/bin/bash
-git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js
+git clone git@github.com:senseobservationsystems/goalie-js.git --single-branch --branch v0.39.2 ./build/goalie-js || exit 2

--- a/script/server
+++ b/script/server
@@ -1,3 +1,3 @@
 #!/bin/bash
-(cd ./niceday-broker || exit ; ./script/bootstrap)
+(cd ./niceday-broker || exit; ./script/bootstrap) || exit
 docker-compose --env-file .env up --build --force-recreate

--- a/script/server
+++ b/script/server
@@ -1,3 +1,3 @@
 #!/bin/bash
 (cd ./niceday-broker || exit ; ./script/bootstrap)
-docker-compose --env-file .env up
+docker-compose --env-file .env up --build --force-recreate

--- a/script/server
+++ b/script/server
@@ -1,0 +1,3 @@
+#!/bin/bash
+(cd ./niceday-broker || exit ; ./script/bootstrap)
+docker-compose --env-file .env up

--- a/script/server
+++ b/script/server
@@ -1,3 +1,3 @@
 #!/bin/bash
 (cd ./niceday-broker || exit; ./script/bootstrap) || exit
-docker-compose --env-file .env up --build --force-recreate
+docker-compose up --build --force-recreate


### PR DESCRIPTION
Fixes #48 by cloning  `goalie-js` repo before building the node.js docker image, for both `niceday-api` and `niceday-broker`. 

I followed conventions from https://github.com/github/scripts-to-rule-them-all .

I think this is not yet an optimal solution, it makes running the application a bit more complicated, but things will improve once we do #73 

@reviewer please see if the instructions make sense and whether you can succesfully run them!