### PR TITLE
Use rasa_server ip address in niceday-broker

### DIFF
--- a/niceday-broker/README.md
+++ b/niceday-broker/README.md
@@ -13,7 +13,9 @@ The rasa response is then sent back to the user in the Niceday app.
 Set THERAPIST_EMAIL_ADDRESS and THERAPIST_PASSWORD in your `.env` file, see .env-example. 
 These will be loaded as environment variables and will thus be available in the app.
 You will get a `InvalidUsernamePasswordError` if the username or password is invalid.
-
+4. Optionally you can configure the rasa agent url by changing the `RASA_AGENT_URL` 
+variable in the `.env` file (see `.env-example`). For example if you want to connect to
+localhost instead of `rasa_server` (the default).
 
 ### Running the server
 To run the server, run:

--- a/niceday-broker/index.js
+++ b/niceday-broker/index.js
@@ -12,7 +12,7 @@ require('dotenv').config();
 
 const { THERAPIST_PASSWORD, THERAPIST_EMAIL_ADDRESS } = process.env;
 let { RASA_AGENT_URL } = process.env;
-RASA_AGENT_URL = (RASA_AGENT_URL === undefined) ? 'http://localhost:5005/webhooks/rest/webhook' : RASA_AGENT_URL;
+RASA_AGENT_URL = (RASA_AGENT_URL === undefined) ? 'http://rasa_server:5005/webhooks/rest/webhook' : RASA_AGENT_URL;
 
 const chatSdk = new Chat();
 const authSdk = new Authentication(SenseServer.Alpha);


### PR DESCRIPTION
Use rasa_server ip address in niceday-broker instead of `localhost`. On windows this allows connecting to the rasa_server in a docker compose setting.

Fixes #123 