### PR TITLE
Rasa env

### DIFF
--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -33,6 +33,7 @@ jobs:
       run: | 
         cd Rasa_Bot
         rasa telemetry disable
+        python
         import yaml
         f = open("config.yml")
         config_dict = yaml.load(f)

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -33,6 +33,9 @@ jobs:
       id: hist
       run:
         echo "::set-output name=hist::$(python rasa_get_max_history.py)"
+    - name: Print hist
+      run: 
+        echo "${{ steps.hist.outputs.hist}}"
     - name: Rasa Data Validation
       run: |
         cd Rasa_Bot

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get max history from config
       id: hist
       run:
-        echo "::set-output name=hist::$(python rasa_get_max_history.py)"
+        echo "::set-output name=hist::$(python ".github/workflows/rasa_get_max_history.py")"
     - name: Print hist
       run: 
         echo "${{ steps.hist.outputs.hist}}"

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         import yaml
         f = open("Rasa_Bot/config.yml")
-        config_dict = yaml.load(f)
+        config_dict = yaml.load(f, Loader=SafeLoader)
         hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
       shell: python
     - name: Rasa Data Validation

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r Rasa_Bot/requirements.txt
+        pip install -r Rasa_Bot/requirements-dev.txt
     # The number for max-history needs to be adapted based on config.yml
     - name: Get max history from config
       run: |

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - rasa_env
   pull_request:
       types: [opened, synchronize, reopened]
 
@@ -28,14 +27,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r Rasa_Bot/requirements-dev.txt
-    # The number for max-history needs to be adapted based on config.yml
-    - name: Get max history from config
+    - name: Get max history from Rasa config-file
       id: hist
       run:
         echo "::set-output name=hist::$(python ".github/workflows/rasa_get_max_history.py")"
-    - name: Print hist
-      run: 
-        echo "${{ steps.hist.outputs.hist}}"
     - name: Rasa Data Validation
       run: |
         cd Rasa_Bot

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -34,7 +34,7 @@ jobs:
         import yaml
         from yaml.loader import SafeLoader
         f = open("Rasa_Bot/config.yml")
-        config_dict = yaml.load(f, Loader=SafeLoader)
+        a = yaml.load(f, Loader=SafeLoader)
         hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
       shell: python
     - name: Rasa Data Validation

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get max history from config
       run: |
         import yaml
-        f = open("config.yml")
+        f = open("Rasa_Bot/config.yml")
         config_dict = yaml.load(f)
         hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
       shell: python

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - rasa_env
   pull_request:
       types: [opened, synchronize, reopened]
 
@@ -32,7 +33,12 @@ jobs:
       run: | 
         cd Rasa_Bot
         rasa telemetry disable
-        rasa data validate --max-history 10
+        import yaml
+        f = open("config.yml")
+        config_dict = yaml.load(f)
+        hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
+        f.close()
+        rasa data validate --max-history hist
   training-testing:
     name: Train and Test model
     runs-on: ubuntu-latest

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -39,6 +39,7 @@ jobs:
         config_dict = yaml.load(f)
         hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
         f.close()
+        exit()
         rasa data validate --max-history hist
   training-testing:
     name: Train and Test model

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Get max history from config
       run: |
         import yaml
+        from yaml.loader import SafeLoader
         f = open("Rasa_Bot/config.yml")
         config_dict = yaml.load(f, Loader=SafeLoader)
         hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -30,18 +30,16 @@ jobs:
         pip install -r Rasa_Bot/requirements-dev.txt
     # The number for max-history needs to be adapted based on config.yml
     - name: Get max history from config
-      run: |
-        import yaml
-        from yaml.loader import SafeLoader
-        f = open("Rasa_Bot/config.yml")
-        a = yaml.load(f, Loader=SafeLoader)
-        hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
-      shell: python
+      id: hist
+      run:
+        echo "::set-output name=hist::$(python rasa_get_max_history.py)"
     - name: Rasa Data Validation
       run: |
         cd Rasa_Bot
         rasa telemetry disable
-        rasa data validate --max-history hist
+        rasa data validate --max-history $HIST
+      env:
+        HIST: ${{ steps.hist.outputs.hist }}
   training-testing:
     name: Train and Test model
     runs-on: ubuntu-latest

--- a/.github/workflows/rasa-tests.yml
+++ b/.github/workflows/rasa-tests.yml
@@ -20,26 +20,26 @@ jobs:
       working-directory: ./Rasa_Bot
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r Rasa_Bot/requirements.txt
     # The number for max-history needs to be adapted based on config.yml
-    - name: Rasa Data Validation
-      run: | 
-        cd Rasa_Bot
-        rasa telemetry disable
-        python
+    - name: Get max history from config
+      run: |
         import yaml
         f = open("config.yml")
         config_dict = yaml.load(f)
         hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
-        f.close()
-        exit()
+      shell: python
+    - name: Rasa Data Validation
+      run: |
+        cd Rasa_Bot
+        rasa telemetry disable
         rasa data validate --max-history hist
   training-testing:
     name: Train and Test model
@@ -48,10 +48,10 @@ jobs:
     - data-validation
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/rasa_get_max_history.py
+++ b/.github/workflows/rasa_get_max_history.py
@@ -1,0 +1,8 @@
+import yaml
+from yaml.loader import SafeLoader
+
+f = open("Rasa_Bot/config.yml")
+a = yaml.load(f, Loader=SafeLoader)
+hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
+
+print(hist)

--- a/.github/workflows/rasa_get_max_history.py
+++ b/.github/workflows/rasa_get_max_history.py
@@ -1,8 +1,14 @@
+"""
+Get highest max_history value from Rasa config-file for Rasa data validation in CI.
+"""
+
 import yaml
 from yaml.loader import SafeLoader
+
 
 f = open("Rasa_Bot/config.yml")
 a = yaml.load(f, Loader=SafeLoader)
 hist = max([a['policies'][i]['max_history'] for i in range(len(a['policies'])) if not a['policies'][i]['name'] == 'RulePolicy'])
+
 
 print(hist)

--- a/Rasa_Bot/.env-example
+++ b/Rasa_Bot/.env-example
@@ -1,4 +1,1 @@
-THERAPIST_EMAIL_ADDRESS=example@mail.com
-THERAPIST_PASSWORD=supersecretpassword
-RASA_AGENT_URL=http://localhost:5005/webhooks/rest/webhook
 RASA_VERSION=2.8.1

--- a/Rasa_Bot/.env-example
+++ b/Rasa_Bot/.env-example
@@ -1,0 +1,4 @@
+THERAPIST_EMAIL_ADDRESS=example@mail.com
+THERAPIST_PASSWORD=supersecretpassword
+RASA_AGENT_URL=http://localhost:5005/webhooks/rest/webhook
+RASA_VERSION=2.8.1

--- a/Rasa_Bot/README.md
+++ b/Rasa_Bot/README.md
@@ -9,12 +9,11 @@ The steps are as follows:
 - Start the database via docker-compose, apply the existing migrations and load test data (see [here](https://github.com/PerfectFit-project/virtual-coach-db).
 - Create a .env-file in the Rasa_Bot/actions-folder that contains the host address and port of the running database in the variable DB_HOST. If the database is running on localhost on Windows or Mac and you want to access it from inside a Docker container, set DB_Host to host.docker.internal:<port_number> (see .env-example).
 - Navigate to the "Rasa_Bot"-folder on your laptop.
+- Make sure you have a .env-file in this folder. This should be modeled after the .env-example-file.
 - Type `docker-compose up`.
 - Now you can communicate with the bot via its REST API. E.g. on Windows, type `curl http://localhost:5005/webhooks/rest/webhook -d "{\"message\": \"Kan ik de agenda voor de week krijgen?\", \"sender\":\"user\"}"`. Note that the escaping of the double-quotes is a fix that is needed on Windows.
    - The output for the above command should be something like this: [{"recipient_id":"user","text":"Sure, you should ..."}]
    - See [this page](https://rasa.com/docs/rasa/connectors/your-own-website#restinput) for details on how to use the REST channel.
-
-Note that while the requirements-file lists Rasa 2.8.1 as a requirement, this is only needed to train a language model and handy when developing.
 
 NB: If you want to run rasa outside of docker, you might want to change the urls
 in `endpoints.yml`.
@@ -66,4 +65,4 @@ The timeout is currently set to 5 minutes (in the "domain.yml"-file). This is th
 In case the new custom action code requires any libraries, these need to be added to "requirements-actions.txt" in the "actions"-folder.
 
 ### Retraining when making changes to Language Model
-Any changes made to domain.yml, nlu.yml, config.yml, stories.yml, among others, require retraining the model via `rasa train`. It is important to pay attention to the Rasa version that is used for this training. If the Rasa version is changed, then the Rasa SDK version in the Dockerfile and the Rasa version in the docker-compose.yml file also need to be updated.
+Any changes made to domain.yml, nlu.yml, config.yml, stories.yml, among others, require retraining the model via `rasa train`. It is important to pay attention to the Rasa version that is used for this training. If the Rasa version is changed, then the Rasa SDK version in the .env-file and the Rasa version in requirementx.txt also need to be updated.

--- a/Rasa_Bot/actions/Dockerfile
+++ b/Rasa_Bot/actions/Dockerfile
@@ -1,7 +1,9 @@
 # Dockerfile for rasa actions server
 
+ARG rasa_vers
+
 # Pull SDK image as base image, version must be compatble with Rasa version
-FROM rasa/rasa-sdk:2.8.1
+FROM rasa/rasa-sdk:$rasa_vers
 
 # Use subdirectory as working directory
 WORKDIR /app

--- a/Rasa_Bot/docker-compose.yml
+++ b/Rasa_Bot/docker-compose.yml
@@ -8,5 +8,8 @@ services:
       - ./:/app
     expose: ["5005"]
   rasa_actions:
-    build: actions/
+    build: 
+      context: actions/
+      args:
+        rasa_vers: ${RASA_VERSION}
     expose: ["5055"]

--- a/Rasa_Bot/requirements-dev.txt
+++ b/Rasa_Bot/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-yaml
+pyyaml

--- a/Rasa_Bot/requirements-dev.txt
+++ b/Rasa_Bot/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+yaml

--- a/Rasa_Bot/requirements.txt
+++ b/Rasa_Bot/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/PerfectFit-project/niceday_client
 rasa==2.8.1 # NB! when updating, make sure to also update:
-            # * rasa base image in actions/Dockerfile,
+			# * Rasa version in .env-file.
             # * format of stories, domain.yml etc. if necessary


### PR DESCRIPTION
Fixes #93 .

- There is now a .env-file for Rasa with the Rasa version, which is read in docker.
- The max-history from config.yml is read in the Rasa CI rather than having to hardcode it there.
- Did not find an option to use the Rasa version from the .env-file also in the requirements.txt for pip install.