### PR TITLE
Make the rasa server docker self-contained

### DIFF
--- a/Rasa_Bot/Dockerfile
+++ b/Rasa_Bot/Dockerfile
@@ -5,6 +5,8 @@ FROM python:3.8
 # Use subdirectory as working directory
 WORKDIR /app
 
+COPY . /app
+
 # Change to root user to install dependencies
 USER root
 

--- a/Rasa_Bot/Dockerfile
+++ b/Rasa_Bot/Dockerfile
@@ -2,11 +2,6 @@
 
 FROM python:3.8
 
-# Use subdirectory as working directory
-WORKDIR /app
-
-COPY . /app
-
 # Change to root user to install dependencies
 USER root
 
@@ -16,5 +11,10 @@ RUN pip install -r requirements.txt
 
 # Don't use root user to run code
 USER 1001
+
+# Use subdirectory as working directory
+WORKDIR /app
+
+COPY . /app
 
 ENTRYPOINT ["rasa", "run", "--enable-api"]


### PR DESCRIPTION
Very minor change, but it is necessary to sanitise deployment outside of the virtual-coach-server repo. Rasa server dockerfile now adds the Rasa_Bot dir to itself, instead of requiring it to be mounted locally. Note that if you still want the old behaviour, you just use it in docker-compose as before, explicitly mounting the Rasa_Bot/ to app/. This will clobber the version of app/ that is carried within the container.